### PR TITLE
proper chunked data loading

### DIFF
--- a/src/xibabel/__init__.py
+++ b/src/xibabel/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 
 from nipy.algorithms.diagnostics.timediff import time_slice_diffs
 
-from .loaders import load
+from .loaders import load, save
 
 
 __version__ = "0.0.1a0"

--- a/src/xibabel/__init__.py
+++ b/src/xibabel/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 
 from nipy.algorithms.diagnostics.timediff import time_slice_diffs
 
-from .loaders import load, save
+from .loaders import load, save # noqa:F401
 
 
 __version__ = "0.0.1a0"

--- a/src/xibabel/loaders.py
+++ b/src/xibabel/loaders.py
@@ -184,7 +184,7 @@ def _guess_format(file_path):
 
 
 def load_zarr(file_path):
-    return xr.load_dataarray(file_path, engine='zarr')
+    return xr.open_dataarray(file_path, engine='zarr', chunks='auto')
 
 
 class XibFileError(Exception):

--- a/src/xibabel/loaders.py
+++ b/src/xibabel/loaders.py
@@ -244,7 +244,8 @@ def load(file_path, format=None):
 
 def save(obj, file_path, format=None):
     file_path = Path(file_path)
-    format = _guess_format(file_path)
+    if format is None:
+        format = _guess_format(file_path)
     if format == 'zarr':
         return obj.to_zarr(file_path, mode='w')
     elif format == 'netcdf':


### PR DESCRIPTION
`open_dataarray` does not try to read all of the data up front, whereas `load_dataarray`                                                                                       
does. That still was insufficient for reduced memory footprint, the chunks='auto'
argument is also required to have the dask array reading respect and preserve
the engine (zarr) on-disk chunking

other minor improvements